### PR TITLE
Prevent admin notices being returned in AJAX calls

### DIFF
--- a/mttr-gtm.php
+++ b/mttr-gtm.php
@@ -78,7 +78,7 @@ class MatterKitGTM {
 
 	public function __mttr_admin_notice( $message, $type = 'update-nag' ) {
 
-		if ( is_admin() ) {
+		if ( is_admin() && !defined('DOING_AJAX') ) {
 
 			echo '<div class="' . sanitize_html_class( $type ) . ' notice">';
 			 


### PR DESCRIPTION
Ran into an issue on the Gravity Forms updates page where the admin notice to set the GTM container was being returned in an admin-ajax call and so was displaying twice. Added a check to prevent admin notices being returned during ajax calls.