### PR TITLE
Move GTM elements to align with recommendations by the SEO team

### DIFF
--- a/mttr-gtm.php
+++ b/mttr-gtm.php
@@ -14,13 +14,13 @@ if( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 
 class MatterKitGTM {
-	
- 
+
+
 	function __construct() {
 
 		add_action( 'init', array( $this, '__mttr_check_for_required_hooks' ) );
 		add_action( 'customize_register', array( $this, '__mttr_gtm_customiser_settings' ), 50 );
- 
+
 	}
 
 
@@ -81,10 +81,10 @@ class MatterKitGTM {
 		if ( is_admin() && !defined('DOING_AJAX') ) {
 
 			echo '<div class="' . sanitize_html_class( $type ) . ' notice">';
-			 
+
 				echo '<p>';
 
-					_e( $message, 'mttr' ); 
+					_e( $message, 'mttr' );
 
 				echo '</p>';
 
@@ -115,14 +115,14 @@ class MatterKitGTM {
 
 		// Add a control to upload the logo
 		$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'mttr_gtm_code',
-			
+
 			array(
 
 				'label' => 'Tag Manager ID',
 				'section' => 'mttr_gtm',
 				'settings' => 'mttr_gtm_code',
 
-			) ) 
+			) )
 
 		);
 
@@ -138,9 +138,8 @@ class MatterKitGTM {
 
 	public function mttr_output_gtm_code() {
 
-		add_action( 'wp_head', array( $this, 'mttr_output_gtm_code_head' ), 1 );
-
-		add_action( 'mttr_page_setup', array( $this, 'mttr_output_gtm_code_body' ), 1 );
+		add_action( 'mttr_page_setup', array( $this, 'mttr_output_gtm_code_body' ), 4 );
+		add_action( 'mttr_page_setup', array( $this, 'mttr_output_gtm_code_head' ), 5 );
 
 	}
 
@@ -162,13 +161,17 @@ class MatterKitGTM {
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','<?php echo esc_html( $gtm_id ); ?>');</script>
 <!-- End Google Tag Manager --><?php
 
 		}
 
 	}
+
+
+
+
 
 
 
@@ -183,9 +186,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		if ( $gtm_id ) {
 
 			?><!-- Google Tag Manager (noscript) -->
-	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo esc_html( $gtm_id ); ?>"
-	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-	<!-- End Google Tag Manager (noscript) --><?php
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=<?php echo esc_html( $gtm_id ); ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) --><?php
 
 		}
 
@@ -210,7 +212,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		return false;
 
 	}
- 
+
 }
 
 
@@ -222,7 +224,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
  ---------------------------------------------------------*/
 
 function mttr_run_matter_kit_gtm() {
-	
+
 	$plugin = new MatterKitGTM();
 
 }


### PR DESCRIPTION
The SEO team noticed that the newer websites weren't able to be verified through search console automatically, so requested we use the older placements of the elements. 

Moved the <noscript> and <script> tags to the top of the body.